### PR TITLE
Update cleaning_metadata.py

### DIFF
--- a/code/cleaning_metadata.py
+++ b/code/cleaning_metadata.py
@@ -154,3 +154,4 @@ metadata_df.to_csv('../data/unified_mannheim_metadata_cleaned.csv', index=False)
 metadata_df.to_json("../data/unified_mannheim_metadata_cleaned.json", orient="records")
 
 print("Cleaned unified metadata saved to ../data/unified_mannheim_metadata_cleaned.csv")
+

--- a/code/cleaning_metadata.py
+++ b/code/cleaning_metadata.py
@@ -15,6 +15,7 @@ _RE_MD_HEADINGS   = re.compile(r"(?m)^\s*#{1,6}\s*")
 _RE_MD_EMPH       = re.compile(r"[*_~`]+")
 _RE_WS            = re.compile(r"\s+")
 _RE_LISTY_STR     = re.compile(r"^\s*\[\s*['\"]")
+_RE_DOI           = re.compile(r"(10\.\d{4,9}/\S+)", re.IGNORECASE)
 _MAX_LEN_DEFAULT  = 10000
 
 _MISSING_TOKEN = "NA"
@@ -114,14 +115,40 @@ def clean_title(text) -> str:
 
     return s
 
+def clean_doi(value) -> str:
+    """Cleaning for 'DOI'"""
+    # Treat None/NaN as missing
+    if value is None or pd.isna(value):
+        return _MISSING_TOKEN
+
+    s = str(value).strip()
+    if not s:
+        return _MISSING_TOKEN
+
+    match = _RE_DOI.search(s)
+    if not match:
+        return _MISSING_TOKEN
+
+    doi = match.group(1)
+
+    # Remove unwanted trailing characters
+    doi = doi.rstrip("',;:\" ")
+
+    if not doi:
+        return _MISSING_TOKEN
+
+    return doi
+
 # Apply cleaning functions
 metadata_df["Description"] = metadata_df["Description"].apply(clean_description)
 metadata_df["Title"] = metadata_df["Title"].apply(clean_title)
+metadata_df["DOI"] = metadata_df["DOI"].apply(clean_doi)
 
 # Ensure NA is consistent
 metadata_df["Description"] = metadata_df["Description"].fillna(_MISSING_TOKEN)
 
 # Save to CSV
+
 metadata_df.to_csv('../data/unified_mannheim_metadata_cleaned.csv', index=False)
 # Save your DataFrame to JSON
 metadata_df.to_json("../data/unified_mannheim_metadata_cleaned.json", orient="records")


### PR DESCRIPTION
Extends metadata cleanup for DOI. 

Some entries look like this before cleaning:
['ZA3000, Version 2.0.0', 'ZA3000, Version 2.0.0', '10.4232/1.11362', '10.4232/1.11362', 'doi:10.4232/1.11362']

['ZA5179, Version 3.0.0', 'ZA5179, Version 3.0.0', '10.7804/cses.module1.2015-12-15', '10.7804/cses.module1.2015-12-15', 'doi:10.7804/cses.module1.2015-12-15']

https://madata.bib.uni-mannheim.de/172/, 10.7801/172

doi:10.7910/DVN/V46QHM

The extension only leaves the DOI behind. This makes subsequent processing easier.