### PR TITLE
feat: improve metadata processing, and add dashboard tracking plus minor changes

### DIFF
--- a/code/cleaning_metadata.py
+++ b/code/cleaning_metadata.py
@@ -164,8 +164,8 @@ desired_order = [
     "Type",
     "Title",
     "Creators",
-    "Affiliations",
     "Description",
+    "Affiliations",    
     "Year",
     "License"
 ]
@@ -176,6 +176,20 @@ metadata_df = metadata_df[existing_order + remaining_cols]
 
 # Ensure NA is consistent
 metadata_df["Description"] = metadata_df["Description"].fillna(_MISSING_TOKEN)
+
+# Add cols
+metadata_df.insert(len(metadata_df.columns), "Anmerkungen", "")
+metadata_df.insert(len(metadata_df.columns), "Projekt", "")
+metadata_df.insert(len(metadata_df.columns), "Längsschnittstudie", "")
+metadata_df.insert(0, "Status", "")
+metadata_df.insert(1, "MADATA-ID", "")
+
+# Delet col
+metadata_df = metadata_df.drop(columns=["Date"])
+
+# Delet MADATA metadata
+metadata_df = metadata_df[~metadata_df["Source"].str.contains(r"\bMADATA\b", case=False, na=False)]
+
 
 # Save to CSV
 metadata_df.to_csv('../data/unified_mannheim_metadata_cleaned.csv', index=False)
@@ -201,6 +215,5 @@ for row_idx in range(2, ws.max_row + 1):  # row 1 = header
         cell.font = link_font
 
 wb.save(excel_path)
-
 
 print("Cleaned unified metadata saved to ../data/unified_mannheim_metadata_cleaned.csv")

--- a/code/create_dashboard.py
+++ b/code/create_dashboard.py
@@ -5,50 +5,226 @@ import plotly.graph_objects as go
 import matplotlib.pyplot as plt
 from wordcloud import WordCloud
 import os
+from datetime import datetime
+import textwrap
 
 # ---------- Configuration ----------
+# Prefer the "metadate" variant for tracking updates.
 DATA_PATH = '../data/unified_mannheim_metadata.csv'
+TRACKING_PATH = '../data/madabi_tracking.csv'
 OUTPUT_DIR = '../docs'
 WORDCLOUD_IMG = os.path.join(OUTPUT_DIR, 'title_wordcloud.png')
 HTML_OUTPUT = os.path.join(OUTPUT_DIR, 'index.html')
+SOURCE_COLOR_MAP = {
+    'MADATA': '#66c2a5',
+    'GESIS': '#fc8d62',
+    'Harvard Dataverse': '#8da0cb',
+    'Zenodo': '#e78ac3',
+}
 
 
 # ---------- Data Loading ----------
 def load_and_prepare_data(path):
     df = pd.read_csv(path)
-    df['Year'] = pd.to_numeric(df['Year'], errors='coerce').dropna().astype('Int64')
-    df['Source_clean'] = df['Source'].fillna('Unknown')
+    df['Year'] = pd.to_numeric(df['Year'], errors='coerce').astype('Int64')
+    df['Source_clean'] = df['Source'].fillna('Unknown').astype(str).str.strip()
+    df.loc[df['Source_clean'] == '', 'Source_clean'] = 'Unknown'
     df['Affiliations_clean'] = df['Affiliations'].fillna('').replace({
         'University of Mannheim': 'Universität Mannheim'
     }, regex=False)
     df['Affiliations_clean'] = df['Affiliations_clean'].str.replace(
         r'.*Universität Mannheim.*', 'Universität Mannheim', regex=True
     )
-    df['Title_clean'] = df['Title'].astype(str).str.strip().str.lower()
+    df['Title_clean'] = df['Title'].fillna('').astype(str).str.strip().str.lower()
+    df.loc[df['Title_clean'] == 'nan', 'Title_clean'] = ''
     return df
 
 
-# ---------- Plotting Functions ----------
-def plot_madata_ratio_with_intersection(df):
-    madata_df = df[df['Source_clean'].str.lower() == 'madata']
-    other_df = df[df['Source_clean'].str.lower() != 'madata']
+def compute_total_n(df):
+    if 'Source_clean' not in df.columns:
+        return len(df)
+    return int(df['Source_clean'].notna().sum())
 
-    madata_titles = set(madata_df['Title_clean'].dropna())
-    other_titles = set(other_df['Title_clean'].dropna())
+
+def update_tracking_csv(df, tracking_path):
+    tracking_columns = ['source', 'month', 't', 'dataset', 'intersection', 'total', 'intersection_perc']
+    if os.path.exists(tracking_path):
+        tracking_df = pd.read_csv(tracking_path, sep=';')
+    else:
+        tracking_df = pd.DataFrame(columns=tracking_columns)
+
+    tracking_df = tracking_df.drop_duplicates(subset=['source', 'month'], keep='last')
+    tracking_df = tracking_df.sort_values(by=['t', 'source']).reset_index(drop=True)
+
+    def normalize_month_str(value):
+        if pd.isna(value):
+            return None
+        return str(value).strip().upper()
+
+    def month_sort_key(month_value):
+        # Expected format in existing tracking CSV: "FEB_2026"
+        try:
+            parts = str(month_value).strip().upper().split('_')
+            if len(parts) == 2:
+                month_abbr = parts[0].title()
+                year = int(parts[1])
+                return datetime.strptime(month_abbr, '%b').replace(year=year)
+        except Exception:
+            pass
+        # Ensure a deterministic comparable return type for sorting.
+        return datetime.max
+
+    preferred_sources = ['MADATA', 'GESIS', 'Harvard Dataverse', 'Zenodo']
+    data_sources = [s for s in sorted(df['Source_clean'].dropna().unique()) if str(s).strip() != '']
+    sources = preferred_sources + [s for s in data_sources if s not in preferred_sources]
+    existing_months = set(tracking_df['month'].astype(str)) if len(tracking_df) > 0 else set()
+
+    month_col = None
+    if 'month' in df.columns:
+        month_col = 'month'
+    elif 'Month' in df.columns:
+        month_col = 'Month'
+
+    # If the input contains month snapshots, compute tracking per month.
+    # Otherwise, treat the entire input as the current snapshot.
+    if month_col is not None:
+        df = df.copy()
+        df['__month_norm'] = df[month_col].apply(normalize_month_str)
+        df = df.dropna(subset=['__month_norm'])
+        unparseable_months = []
+        for month_value in sorted(set(df['__month_norm'].astype(str))):
+            parts = str(month_value).strip().upper().split('_')
+            valid = False
+            if len(parts) == 2:
+                try:
+                    datetime.strptime(parts[0].title(), '%b')
+                    int(parts[1])
+                    valid = True
+                except Exception:
+                    valid = False
+            if not valid:
+                unparseable_months.append(month_value)
+        if len(unparseable_months) > 0:
+            print(f"Unparseable tracking month values: {', '.join(unparseable_months[:5])}")
+        derived_months = sorted(set(df['__month_norm'].astype(str)), key=month_sort_key)
+    else:
+        derived_months = [datetime.today().strftime('%b_%Y').upper()]
+
+    months_to_update = set(derived_months)
+    current_max_t = int(pd.to_numeric(tracking_df['t'], errors='coerce').max()) if len(tracking_df) > 0 else -1
+    month_to_existing_t = {}
+    if len(tracking_df) > 0:
+        for m in months_to_update & existing_months:
+            t_max = pd.to_numeric(tracking_df[tracking_df['month'].astype(str) == m]['t'], errors='coerce').max()
+            month_to_existing_t[m] = int(t_max) if pd.notna(t_max) else current_max_t
+    new_months = [m for m in derived_months if m not in existing_months]
+    new_month_to_t = {}
+    for i, m in enumerate(new_months):
+        new_month_to_t[m] = current_max_t + 1 + i
+
+    tracking_remaining = tracking_df[~tracking_df['month'].astype(str).isin(months_to_update)].copy() if len(tracking_df) > 0 else tracking_df
+    new_rows = []
+
+    for month_value in derived_months:
+        if month_col is not None:
+            month_df = df[df['__month_norm'].astype(str) == month_value]
+        else:
+            month_df = df
+
+        madata_titles = set(get_valid_title_series(month_df[month_df['Source_clean'].str.lower() == 'madata']))
+        other_titles = set(get_valid_title_series(month_df[month_df['Source_clean'].str.lower() != 'madata']))
+        shared_titles = madata_titles & other_titles
+        total = int(month_df['Source_clean'].isin(sources).sum())
+        intersection = len(shared_titles)
+        intersection_perc = round((intersection / total * 100), 1) if total > 0 else 0.0
+
+        t_value = month_to_existing_t.get(month_value, new_month_to_t.get(month_value))
+        for source in sources:
+            dataset_count = int((month_df['Source_clean'] == source).sum())
+            new_rows.append({
+                'source': source,
+                'month': month_value,
+                't': t_value,
+                'dataset': dataset_count,
+                'intersection': intersection,
+                'total': total,
+                'intersection_perc': intersection_perc
+            })
+
+    new_df = pd.DataFrame(new_rows, columns=tracking_columns)
+    tracking_df = pd.concat([tracking_remaining, new_df], ignore_index=True)
+    tracking_df = tracking_df.drop_duplicates(subset=['source', 'month'], keep='last')
+    tracking_df = tracking_df.sort_values(by=['t', 'source']).reset_index(drop=True)
+
+    tracking_df.to_csv(tracking_path, sep=';', index=False)
+    return tracking_df
+
+
+# ---------- Plotting Functions ----------
+def wrap_title(title, width=45):
+    if title is None:
+        return title
+    title = str(title)
+    if len(title) <= width:
+        return title
+    return '<br>'.join(textwrap.wrap(title, width=width))
+
+
+def format_count_percentage(count, total):
+    percentage = (count / total * 100) if total > 0 else 0.0
+    return f"{count} ({percentage:.1f}%)"
+
+
+def get_source_color_map(sources):
+    color_map = dict(SOURCE_COLOR_MAP)
+    fallback_colors = px.colors.qualitative.Pastel
+    unknown_sources = [s for s in sorted(set(sources)) if s not in color_map]
+    for i, source in enumerate(unknown_sources):
+        color_map[source] = fallback_colors[i % len(fallback_colors)]
+    return color_map
+
+
+def get_valid_title_series(df):
+    return df.loc[df['Title_clean'].notna() & (df['Title_clean'] != ''), 'Title_clean']
+
+
+def log_data_quality(df):
+    missing_source = int(df['Source_clean'].isna().sum() + (df['Source_clean'] == '').sum())
+    missing_title = int(df['Title_clean'].isna().sum() + (df['Title_clean'] == '').sum())
+    missing_year = int(df['Year'].isna().sum())
+    unknown_sources = sorted([s for s in df['Source_clean'].dropna().unique() if s not in SOURCE_COLOR_MAP])
+
+    if missing_source > 0:
+        print(f"Missing source values: {missing_source}")
+    if missing_title > 0:
+        print(f"Missing title values: {missing_title}")
+    if missing_year > 0:
+        print(f"Missing/invalid year values: {missing_year}")
+    if len(unknown_sources) > 0:
+        print(f"Additional sources detected: {', '.join(unknown_sources)}")
+
+
+def plot_madata_ratio_with_intersection(df, total_n):
+    madata_df = df[df['Source_clean'] == 'MADATA']
+    other_df = df[df['Source_clean'] != 'MADATA']
+
+    madata_titles = set(get_valid_title_series(madata_df))
+    other_titles = set(get_valid_title_series(other_df))
     shared_titles = madata_titles & other_titles
 
-    madata_only = madata_titles
-    other_only = other_titles
+    madata_count = int((df['Source_clean'] == 'MADATA').sum())
+    other_count = int((df['Source_clean'] != 'MADATA').sum())
+    intersection_count = int(madata_df['Title_clean'].isin(shared_titles).sum())
 
     overlap_df = pd.DataFrame({
         'Category': ['MADATA', 'Other Repos', 'Intersection'],
-        'Count': [len(madata_only), len(other_only), len(shared_titles)],
+        'Count': [madata_count, other_count, intersection_count],
     })
 
-    total = overlap_df['Count'].sum()
-    overlap_df['Percentage'] = overlap_df['Count'] / total * 100
+    total = madata_count + other_count
+    overlap_df['Percentage'] = overlap_df['Count'] / total * 100 if total > 0 else 0.0
     overlap_df['Label'] = overlap_df.apply(
-        lambda row: f"<b>{row['Count']}</b><br>{row['Percentage']:.1f}%", axis=1
+        lambda row: format_count_percentage(row['Count'], total), axis=1
     )
 
     fig = px.bar(
@@ -57,59 +233,63 @@ def plot_madata_ratio_with_intersection(df):
         y="Count",
         color="Category",
         text="Label",
-        title="Datasets in MADATA & Other Repositories",
-        color_discrete_sequence=px.colors.qualitative.Set2
+        title=wrap_title(f"Datasets in MADATA & Other Repositories (n={total_n})"),
+        color_discrete_sequence=px.colors.qualitative.Set2,
+        labels={'Count': 'Number of Datasets'}
     )
     fig.update_layout(
         width=600,
         height=400,
         showlegend=False,
-        yaxis=dict(range=[0, overlap_df['Count'].max() * 1.2])
+        yaxis=dict(range=[0, overlap_df['Count'].max() * 1.2]),
+        title_x=0
     )
-    fig.update_traces(textposition='outside')
+    fig.update_traces(textposition='outside', cliponaxis=False)
     return fig
 
 
-def plot_dataset_source_distribution(df):
-    source_counts = df['Source'].value_counts().reset_index()
+def plot_dataset_source_distribution(df, total_n):
+    source_counts = df['Source_clean'].value_counts().reset_index()
     source_counts.columns = ['Source', 'Count']
     source_counts = source_counts.sort_values(by='Count', ascending=False)
     total = source_counts['Count'].sum()
     source_counts['Label'] = source_counts.apply(
-        lambda row: f"{row['Count']} ({(row['Count'] / total * 100):.1f}%)", axis=1
+        lambda row: format_count_percentage(row['Count'], total), axis=1
     )
-    fig = go.Figure(data=[go.Pie(
-        labels=source_counts['Source'],
-        values=source_counts['Count'],
-        hole=0.5,
-        marker=dict(colors=px.colors.qualitative.Pastel),
-        text=source_counts['Label'],
-        textinfo='text',
-        textposition='inside',
-        hovertemplate="<b>%{label}</b><br>Count: %{value}<br>Share: %{percent}<extra></extra>",
-    )])
+    fig = px.bar(
+        source_counts,
+        x='Source',
+        y='Count',
+        color='Source',
+        title=wrap_title(f'Datasets per Source (n={total_n})'),
+        text='Label',
+        color_discrete_map=get_source_color_map(source_counts['Source']),
+        labels={'Count': 'Number of Datasets'}
+    )
     fig.update_layout(
-        annotations=[dict(
-            text=f"<b>Total</b><br>{total}", 
-            x=0.5, y=0.5, font_size=16, showarrow=False
-        )],
-        title='Datasets per Source',
         width=600,
         height=450,
-        showlegend=True,
-        legend_title_text='Source',
+        showlegend=False,
         margin=dict(t=80, b=20, l=20, r=20),
-        title_x=0.5
+        title_x=0
+    )
+    fig.update_traces(
+        textposition='outside',
+        cliponaxis=False,
+        hovertemplate="<b>%{x}</b><br>Number of Datasets: %{y}<extra></extra>"
     )
     return fig
 
 
-def plot_yearly_dataset_bar(df):
-    year_source = df.groupby(['Year', 'Source']).size().reset_index(name='Count').dropna()
+def plot_yearly_dataset_bar(df, total_n):
+    year_source = df.groupby(['Year', 'Source_clean']).size().reset_index(name='Count').dropna()
+    year_source = year_source.rename(columns={'Source_clean': 'Source'})
     fig = px.bar(year_source, x='Year', y='Count', color='Source',
-                 title='Datasets per Year by Source', text='Count',
-                 color_discrete_sequence=px.colors.qualitative.Set2)
-    fig.update_layout(width=600, height=400)
+                 title=wrap_title(f'Datasets per Year by Source (n={total_n})'), text='Count',
+                 color_discrete_map=get_source_color_map(year_source['Source']),
+                 labels={'Count': 'Number of Datasets'})
+    fig.update_layout(width=600, height=400, title_x=0)
+    fig.update_traces(cliponaxis=False)
     return fig
 
 
@@ -117,18 +297,55 @@ def plot_top_creators(df):
     creators_series = df['Creators'].dropna().str.split(';').explode().value_counts().head(30).reset_index()
     creators_series.columns = ['Creator', 'Count']
     fig = px.bar(creators_series, y='Creator', x='Count', orientation='h',
-                 title='Top 30 Creators', color='Count',
-                 color_continuous_scale='Tealgrn', text='Count')
-    fig.update_layout(width=1000, height=1000, yaxis=dict(autorange="reversed"), showlegend=False)
+                 title=wrap_title('Top 30 Creators'), color='Count',
+                 color_continuous_scale='Tealgrn', text='Count',
+                 labels={'Count': 'Number of Datasets'})
+    fig.update_layout(width=1000, height=1000, yaxis=dict(autorange="reversed"), showlegend=False, title_x=0)
     fig.update_traces(textposition='inside')
     return fig
 
 
-def plot_yearly_line_trend(df):
-    year_source = df.groupby(['Year', 'Source']).size().reset_index(name='Count').dropna()
+def plot_yearly_line_trend(df, total_n):
+    year_source = df.groupby(['Year', 'Source_clean']).size().reset_index(name='Count').dropna()
+    year_source = year_source.rename(columns={'Source_clean': 'Source'})
     fig = px.line(year_source, x='Year', y='Count', color='Source', markers=True,
-                  title='Yearly Dataset Trend per Source')
-    fig.update_layout(width=600, height=400)
+                  title=wrap_title(f'Yearly Dataset Trend per Source (n={total_n})'),
+                  color_discrete_map=get_source_color_map(year_source['Source']),
+                  labels={'Count': 'Number of Datasets', 'Year': 'Year', 'Source': 'Source'})
+    fig.update_layout(width=600, height=400, title_x=0)
+    return fig
+
+
+def plot_tracking_line_trend(tracking_df, total_n):
+    tracking_df = tracking_df.sort_values(by=['t', 'source'])
+    fig = px.line(
+        tracking_df,
+        x='month',
+        y='dataset',
+        color='source',
+        markers=True,
+        title=wrap_title(f'Datasets per Source and Intersection with MADATA over Time (n={total_n})'),
+        color_discrete_map=get_source_color_map(tracking_df['source']),
+        labels={'dataset': 'Number of Datasets', 'month': 'Month', 'source': 'Source'}
+    )
+
+    intersection_df = tracking_df.groupby('month', as_index=False).agg({
+        't': 'max',
+        'intersection': 'max',
+        'intersection_perc': 'max'
+    })
+    intersection_df = intersection_df.sort_values(by='t')
+    fig.add_trace(go.Scatter(
+        x=intersection_df['month'],
+        y=intersection_df['intersection'],
+        mode='lines+markers',
+        name='Intersection with MADATA',
+        line=dict(color='black', dash='dash'),
+        marker=dict(size=8),
+        customdata=intersection_df['intersection_perc'],
+        hovertemplate="<b>%{x}</b><br>Intersection with MADATA: %{y}<br>Intersection (%): %{customdata[0]:.1f}%<extra></extra>"
+    ))
+    fig.update_layout(width=600, height=400, title_x=0)
     return fig
 
 
@@ -146,27 +363,33 @@ def generate_wordcloud(df, output_path):
 
 # ---------- HTML Export ----------
 def generate_html(figures, wordcloud_path, output_path):
-    plots_html = '\n'.join(
+    main_plots_html = '\n'.join(
         f"<div class='plot'>{pio.to_html(fig, full_html=False, include_plotlyjs=('cdn' if i == 0 else False))}</div>"
-        for i, fig in enumerate(figures)
+        for i, fig in enumerate(figures[:5])
     )
+    top_creators_plot_html = ""
+    if len(figures) > 5:
+        top_creators_plot_html = f"<div class='plot plot-full'>{pio.to_html(figures[5], full_html=False, include_plotlyjs=False)}</div>"
     html = f"""
     <html>
     <head>
       <title>Mannheim Data Bibliography Dashboard</title>
       <style>
+        :root {{ --plot-gap: 20px; }}
         body {{ font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f8f9fa; padding: 20px; color: #343a40; }}
         h1 {{ text-align: center; margin-bottom: 40px; }}
-        .plot-container {{ display: flex; flex-wrap: wrap; justify-content: center; gap: 20px; }}
+        .plot-container {{ display: flex; flex-wrap: wrap; justify-content: center; gap: var(--plot-gap); }}
         .plot {{ box-shadow: 0 4px 6px rgba(0,0,0,0.1); border-radius: 10px; background-color: white; padding: 10px; }}
+        .plot-full {{ width: 100%; max-width: 1100px; margin: var(--plot-gap) auto 0 auto; }}
         .image-plot {{ width: 800px; margin: 0 auto; display: block; border-radius: 10px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); }}
       </style>
     </head>
     <body>
       <h1>Mannheim Data Bibliography Dashboard</h1>
       <div class='plot-container'>
-        {plots_html}
+        {main_plots_html}
       </div>
+      {top_creators_plot_html}
       <h2 style='text-align: center;'>Most Frequent Terms in Titles</h2>
       <img src='title_wordcloud.png' alt='Title WordCloud' class='image-plot'/>
     </body>
@@ -179,21 +402,27 @@ def generate_html(figures, wordcloud_path, output_path):
 # ---------- Main ----------
 def main():
     os.makedirs(OUTPUT_DIR, exist_ok=True)
+    if not os.path.exists(DATA_PATH):
+        raise FileNotFoundError(f"Data file not found: {DATA_PATH}")
     df = load_and_prepare_data(DATA_PATH)
+    log_data_quality(df)
+    tracking_df = update_tracking_csv(df, TRACKING_PATH)
+    total_n = compute_total_n(df)
 
     # Generate visualizations
     figures = [
-        plot_madata_ratio_with_intersection(df),
-        plot_dataset_source_distribution(df),
-        plot_yearly_dataset_bar(df),
-        plot_yearly_line_trend(df),
+        plot_madata_ratio_with_intersection(df, total_n),
+        plot_dataset_source_distribution(df, total_n),
+        plot_yearly_dataset_bar(df, total_n),
+        plot_yearly_line_trend(df, total_n),
+        plot_tracking_line_trend(tracking_df, total_n),
         plot_top_creators(df),
     ]
 
     generate_wordcloud(df, WORDCLOUD_IMG)
     generate_html(figures, WORDCLOUD_IMG, HTML_OUTPUT)
 
-    print(f"✅ Dashboard saved to: {HTML_OUTPUT}")
+    print(f"Dashboard saved to: {HTML_OUTPUT}")
 
 
 if __name__ == "__main__":

--- a/code/harvester/harvard_dataverse.py
+++ b/code/harvester/harvard_dataverse.py
@@ -20,20 +20,20 @@ params = {
 }
 
 all_datasets = []
-print("🔍 Starting metadata harvest from Harvard Dataverse...")
+print("Starting metadata harvest from Harvard Dataverse...")
 
 # Step 1: First request to get total count
 first_response = requests.get(search_url, params=params)
 first_response.raise_for_status()
 first_data = first_response.json()['data']
 total = first_data['total_count']
-print(f"📦 Total datasets to harvest: {total}")
+print(f"Total datasets to harvest: {total}")
 
 # Reset for iteration
 params['start'] = 0
 
 # Step 2: Iterate with tqdm progress bar
-with tqdm(total=total, desc="⏳ Harvesting", unit="dataset") as pbar:
+with tqdm(total=total, desc="Harvesting", unit="dataset") as pbar:
     while True:
         response = requests.get(search_url, params=params)
         response.raise_for_status()
@@ -54,7 +54,7 @@ with tqdm(total=total, desc="⏳ Harvesting", unit="dataset") as pbar:
                 metadata_json = meta_response.json()
                 license_info = metadata_json['data'].get('schema:license', 'N/A')
             except Exception as e:
-                print(f"⚠️ License lookup failed for {doi}: {e}")
+                print(f"License lookup failed for {doi}: {e}")
 
             all_datasets.append({
                 'Title': item.get('name'),
@@ -76,4 +76,4 @@ with tqdm(total=total, desc="⏳ Harvesting", unit="dataset") as pbar:
 # Save to CSV
 df = pd.DataFrame(all_datasets)
 df.to_csv('../data/harvard_dataverse.csv', index=False)
-print(f"\n✅ Done! {len(df)} datasets saved to ../data/harvard_dataverse.csv")
+print(f"\nDone! {len(df)} datasets saved to ../data/harvard_dataverse.csv")

--- a/code/merge_metadata.py
+++ b/code/merge_metadata.py
@@ -10,7 +10,21 @@ harvard_df = pd.read_csv('../data/harvard_dataverse.csv')
 # Standardize date columns explicitly
 gesis_df['Year'] = gesis_df['Year'].apply(lambda x: pd.to_datetime(x, errors='coerce', dayfirst=True).year)
 madata_df['raw_metadata'] = madata_df['raw_metadata'].apply(eval)
-madata_df['Year'] = madata_df['raw_metadata'].apply(lambda x: x.get('date')[0:4])
+def _year_from_raw_metadata(x):
+    if not isinstance(x, dict):
+        return pd.NA
+    d = x.get('date')
+    if d is None:
+        return pd.NA
+    # Handle list-like dates defensively
+    if isinstance(d, list):
+        d = d[0] if len(d) > 0 else None
+    if d is None:
+        return pd.NA
+    s = str(d).strip()
+    return s[:4] if len(s) >= 4 else pd.NA
+
+madata_df['Year'] = madata_df['raw_metadata'].apply(_year_from_raw_metadata)
 zenodo_df['Year'] = pd.to_datetime(zenodo_df['Publication Date'], errors='coerce').dt.year
 harvard_df['Year'] = pd.to_datetime(harvard_df['Published At'], errors='coerce').dt.year
 

--- a/data/madabi_tracking.csv
+++ b/data/madabi_tracking.csv
@@ -1,0 +1,9 @@
+source;month;t;dataset;intersection;total;intersection_perc
+GESIS;FEB_2026;0;529;9;1079;0.8
+Harvard Dataverse;FEB_2026;0;229;9;1079;0.8
+MADATA;FEB_2026;0;195;9;1079;0.8
+Zenodo;FEB_2026;0;126;9;1079;0.8
+GESIS;MAR_2026;1;538;76;1164;6.5
+Harvard Dataverse;MAR_2026;1;233;76;1164;6.5
+MADATA;MAR_2026;1;266;76;1164;6.5
+Zenodo;MAR_2026;1;127;76;1164;6.5


### PR DESCRIPTION
extend cleaning_metadata.py:
- add project-specific output columns (Status, MADATA-ID, Anmerkungen, Projekt, Laengsschnittstudie) drop Date column from cleaned output
- exclude MADATA records from cleaned dataset
- adjust column ordering

improve merge_metadata.py:
- replace direct year extraction for MADATA with safer helper function handle missing, malformed, and list-based date values more robustly

enhance create_dashboard.py:
- improve preprocessing of source and title fields
- add data quality checks and helper functions
- introduce monthly tracking logic (intersection with MADATA and dataset counts) add new time series visualization for tracking development over time refine existing plots and improve HTML layout

add madabi_tracking.csv:
- stored in data/ directory
- updated automatically once per month via create_dashboard.py

update harvard_dataverse.py:
- minor adjustments only
- ensure ASCII-only output text for compatibility

These changes improve robustness of the metadata pipeline, extend the dashboard with longitudinal tracking capabilities, and standardize output handling.